### PR TITLE
Analyze maker folder for critical errors

### DIFF
--- a/Maker/Makr.py
+++ b/Maker/Makr.py
@@ -225,23 +225,25 @@ import atexit
 atexit.register(cleanup_database_connections)
 
 # تعيين التبعيات لمجلد users
-set_dependencies(OWNER_ID, devs_collection, users)
+# تم نقل هذا الاستدعاء إلى main.py لتجنب التكرار
+# set_dependencies(OWNER_ID, devs_collection, users)
 
 # تعيين المجموعات لمجلد db
-set_db_collections(broadcasts_collection, bots_collection, factory_settings)
+# تم نقل هذه الاستدعاءات إلى main.py لتجنب التكرار
+# set_db_collections(broadcasts_collection, bots_collection, factory_settings)
 
 # تعيين المجموعات لمجلد bots
-set_bots_collections(bots_collection, factory_settings)
+# set_bots_collections(bots_collection, factory_settings)
 
 # تعيين المجموعات لمجلد broadcast
-set_broadcast_collections(broadcasts_collection)
+# set_broadcast_collections(broadcasts_collection)
 
 # تعيين المجموعات لمجلد factory
-set_factory_collections(factory_settings)
+# set_factory_collections(factory_settings)
 
 # تعيين التبعيات لمعالجات الأوامر
-from handlers.commands import set_dependencies as set_commands_dependencies
-from handlers.broadcast import set_dependencies as set_broadcast_dependencies
+# from handlers.commands import set_dependencies as set_commands_dependencies
+# from handlers.broadcast import set_dependencies as set_broadcast_dependencies
 
-set_commands_dependencies(OWNER_ID, bots_collection)
-set_broadcast_dependencies(bots_collection)
+# set_commands_dependencies(OWNER_ID, bots_collection)
+# set_broadcast_dependencies(bots_collection)

--- a/main.py
+++ b/main.py
@@ -144,13 +144,13 @@ class BotFactory:
         """إعداد التبعيات لجميع الوحدات"""
         try:
             # إعداد تبعيات المستخدمين
-            set_users_dependencies(OWNER_ID, self.users)
+            set_users_dependencies(OWNER_ID, self.devs_collection, self.users)
             
             # إعداد تبعيات قاعدة البيانات
-            set_db_collections(self.users, self.chats, self.mkchats, self.blockeddb)
+            set_db_collections(self.broadcasts_collection, self.bots_collection, self.factory_settings)
             
             # إعداد تبعيات البوتات
-            set_bots_collections(self.bots_collection)
+            set_bots_collections(self.bots_collection, self.factory_settings)
             
             # إعداد تبعيات البث
             set_broadcast_collections(self.broadcasts_collection)
@@ -162,7 +162,7 @@ class BotFactory:
             set_commands_dependencies(OWNER_ID, self.bots_collection)
             
             # إعداد تبعيات البث
-            set_broadcast_dependencies(OWNER_ID, self.bots_collection)
+            set_broadcast_dependencies(self.bots_collection)
             
             logger.info("Dependencies setup completed successfully")
             


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix `TypeError: missing required positional argument` in dependency setup functions and remove redundant initialization calls.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses a critical runtime error (`set_dependencies() missing 1 required positional argument: 'users_coll'`) by correcting the number and type of arguments passed to various `set_dependencies` and `set_collections` functions in `main.py`. Additionally, redundant initialization calls in `Maker/Makr.py` were commented out to prevent duplicate setups and potential conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee31eb13-001f-483b-a76b-2bbaab02a861">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee31eb13-001f-483b-a76b-2bbaab02a861">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>